### PR TITLE
Initialize FoundaBrain foundation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+DATABASE_URL="postgresql://user:password@localhost:5432/foundabrain"
+OPENAI_API_KEY=""

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-# Google App Engine generated folder
-appengine-generated/
+node_modules/
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
-# AI-Marketplace-
+# FoundaBrain
+
+AI-powered freelance marketplace foundation.
+
+## Setup
+
+1. Copy `.env.example` to `.env` and update with your credentials.
+2. Run `npm run setup` to install packages and generate Prisma client.
+3. Use `npm run dev` to start the Next.js frontend.
+4. Run `node api/index.js` or your custom server to start the Express API (see `backend/api`).
+5. Seed sample data with `npm run seed`.

--- a/api/index.js
+++ b/api/index.js
@@ -1,0 +1,22 @@
+const express = require('express');
+const bodyParser = require('body-parser');
+
+const register = require('./routes/register');
+const submitTool = require('./routes/tools.submit');
+const recommendTool = require('./routes/tools.recommend');
+const adminApprove = require('./routes/admin.approve');
+
+const app = express();
+app.use(bodyParser.json());
+
+app.use('/api/register', register);
+app.use('/api/tools/submit', submitTool);
+app.use('/api/tools/recommend', recommendTool);
+app.use('/api/admin/approve', adminApprove);
+
+const port = process.env.PORT || 3001;
+app.listen(port, () => {
+  console.log(`API server running on port ${port}`);
+});
+
+module.exports = app;

--- a/api/routes/admin.approve.js
+++ b/api/routes/admin.approve.js
@@ -1,0 +1,23 @@
+const express = require('express');
+const prisma = require('../../lib/prisma');
+
+const router = express.Router();
+
+router.post('/', async (req, res) => {
+  const { toolId } = req.body;
+  if (!toolId) {
+    return res.status(400).json({ success: false, error: 'toolId required' });
+  }
+  try {
+    const listing = await prisma.toolListing.update({
+      where: { id: toolId },
+      data: { approved: true }
+    });
+    res.json({ success: true, data: listing });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ success: false, error: 'Internal server error' });
+  }
+});
+
+module.exports = router;

--- a/api/routes/register.js
+++ b/api/routes/register.js
@@ -1,0 +1,14 @@
+const express = require('express');
+const router = express.Router();
+
+router.post('/', async (req, res) => {
+  try {
+    // TODO: implement AI wizard for onboarding
+    res.json({ success: true, message: 'Registration placeholder' });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ success: false, error: 'Internal server error' });
+  }
+});
+
+module.exports = router;

--- a/api/routes/tools.recommend.js
+++ b/api/routes/tools.recommend.js
@@ -1,0 +1,22 @@
+const express = require('express');
+const { embedText } = require('../../services/openai');
+const { searchSimilar } = require('../../services/vector');
+
+const router = express.Router();
+
+router.get('/', async (req, res) => {
+  const { query } = req.query;
+  if (!query) {
+    return res.status(400).json({ success: false, error: 'query required' });
+  }
+  try {
+    const embedding = await embedText(query);
+    const results = await searchSimilar(embedding);
+    res.json({ success: true, data: results });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ success: false, error: 'Internal server error' });
+  }
+});
+
+module.exports = router;

--- a/api/routes/tools.submit.js
+++ b/api/routes/tools.submit.js
@@ -1,0 +1,31 @@
+const express = require('express');
+const prisma = require('../../lib/prisma');
+const { generateToolData, embedText } = require('../../services/openai');
+const { storeEmbedding } = require('../../services/vector');
+
+const router = express.Router();
+
+router.post('/', async (req, res) => {
+  const { userId, prompt } = req.body;
+  if (!userId || !prompt) {
+    return res.status(400).json({ success: false, error: 'userId and prompt required' });
+  }
+  try {
+    const aiContent = await generateToolData(prompt);
+    const { title, description } = JSON.parse(aiContent);
+    if (!title || !description) {
+      return res.status(400).json({ success: false, error: 'Invalid AI response' });
+    }
+    const listing = await prisma.toolListing.create({
+      data: { userId, title, description }
+    });
+    const embedding = await embedText(`${title}\n${description}`);
+    await storeEmbedding(listing.id, `${title}\n${description}`, embedding);
+    res.json({ success: true, data: listing });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ success: false, error: 'Internal server error' });
+  }
+});
+
+module.exports = router;

--- a/backend/api/tools/submit.js
+++ b/backend/api/tools/submit.js
@@ -1,0 +1,31 @@
+const express = require('express');
+const prisma = require('../../lib/prisma');
+const { generateToolData, embedText } = require('../../lib/openaiClient');
+const { storeEmbedding } = require('../../lib/vectorService');
+
+const router = express.Router();
+
+router.post('/', async (req, res) => {
+  const { userId, prompt } = req.body;
+  if (!userId || !prompt) {
+    return res.status(400).json({ success: false, error: 'userId and prompt required' });
+  }
+  try {
+    const aiResponse = await generateToolData(prompt);
+    const { title, description } = JSON.parse(aiResponse);
+    if (!title || !description) {
+      return res.status(400).json({ success: false, error: 'Invalid AI response' });
+    }
+    const listing = await prisma.toolListing.create({
+      data: { userId, title, description }
+    });
+    const embedding = await embedText(`${title}\n${description}`);
+    await storeEmbedding(listing.id, `${title}\n${description}`, embedding);
+    res.json({ success: true, data: listing });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ success: false, error: 'Internal server error' });
+  }
+});
+
+module.exports = router;

--- a/frontend/pages/freelancer/dashboard.tsx
+++ b/frontend/pages/freelancer/dashboard.tsx
@@ -1,0 +1,31 @@
+import useSWR from 'swr';
+import axios from 'axios';
+
+interface ToolListing {
+  id: string;
+  title: string;
+  description: string;
+  approved: boolean;
+}
+
+const fetcher = (url: string) => axios.get(url).then(res => res.data);
+
+export default function FreelancerDashboard() {
+  const { data, error } = useSWR<ToolListing[]>('/api/tools', fetcher);
+
+  if (error) return <div>Error loading tools.</div>;
+  if (!data) return <div>Loading...</div>;
+
+  return (
+    <div>
+      <h1>My Tools</h1>
+      <ul>
+        {data.map(tool => (
+          <li key={tool.id}>
+            <strong>{tool.title}</strong> - {tool.approved ? 'Approved' : 'Pending'}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/lib/openaiClient.ts
+++ b/lib/openaiClient.ts
@@ -1,0 +1,22 @@
+import { OpenAI } from 'openai';
+
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+export async function generateToolData(prompt: string): Promise<string> {
+  const completion = await openai.chat.completions.create({
+    model: 'gpt-4o',
+    messages: [
+      { role: 'system', content: 'You are the FoundaBrain AI Wizard.' },
+      { role: 'user', content: prompt }
+    ]
+  });
+  return completion.choices[0]?.message?.content || '';
+}
+
+export async function embedText(text: string): Promise<number[]> {
+  const resp = await openai.embeddings.create({
+    model: 'text-embedding-3-small',
+    input: text
+  });
+  return resp.data[0].embedding as unknown as number[];
+}

--- a/lib/prisma.js
+++ b/lib/prisma.js
@@ -1,0 +1,13 @@
+const { PrismaClient } = require('@prisma/client');
+
+let prisma;
+if (process.env.NODE_ENV === 'production') {
+  prisma = new PrismaClient();
+} else {
+  if (!global.prisma) {
+    global.prisma = new PrismaClient();
+  }
+  prisma = global.prisma;
+}
+
+module.exports = prisma;

--- a/lib/vectorService.ts
+++ b/lib/vectorService.ts
@@ -1,0 +1,11 @@
+import prisma from './prisma';
+
+export async function storeEmbedding(toolId: string, content: string, embedding: number[]) {
+  return prisma.vectorEmbedding.create({
+    data: { toolId, content, embedding }
+  });
+}
+
+export async function searchSimilar(embedding: number[], limit = 5) {
+  return prisma.$queryRaw`SELECT * FROM "VectorEmbedding" ORDER BY embedding <-> ${embedding} LIMIT ${limit}`;
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "foundabrain",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "NODE_ENV=production node api/index.js",
+    "setup": "node scripts/setup.js",
+    "seed": "node prisma/seed.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "next": "13.4.13",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "pg": "^8.11.1",
+    "pgvector": "^0.1.7",
+    "openai": "^4.21.1",
+    "prisma": "^5.9.0",
+    "@prisma/client": "^5.9.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.5",
+    "ts-node": "^10.9.2"
+  }
+}

--- a/pages/customer-wizard.js
+++ b/pages/customer-wizard.js
@@ -1,0 +1,7 @@
+export default function CustomerWizard() {
+  return (
+    <div>
+      <h1>Customer Onboarding Wizard</h1>
+    </div>
+  );
+}

--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -1,0 +1,7 @@
+export default function Dashboard() {
+  return (
+    <div>
+      <h1>Freelancer Dashboard</h1>
+    </div>
+  );
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,0 +1,7 @@
+export default function Home() {
+  return (
+    <div>
+      <h1>Welcome to FoundaBrain</h1>
+    </div>
+  );
+}

--- a/pages/tool-listing.js
+++ b/pages/tool-listing.js
@@ -1,0 +1,7 @@
+export default function ToolListing() {
+  return (
+    <div>
+      <h1>Tool Listing</h1>
+    </div>
+  );
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,43 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model User {
+  id        String   @id @default(uuid())
+  email     String   @unique
+  password  String
+  role      Role
+  createdAt DateTime @default(now())
+  listings  ToolListing[]
+}
+
+enum Role {
+  freelancer
+  customer
+  admin
+}
+
+model ToolListing {
+  id          String   @id @default(uuid())
+  user        User     @relation(fields: [userId], references: [id])
+  userId      String
+  title       String
+  description String
+  createdAt   DateTime @default(now())
+  embedding   VectorEmbedding?
+  approved    Boolean  @default(false)
+}
+
+model VectorEmbedding {
+  id         String   @id @default(uuid())
+  content    String
+  embedding  Float[]  @db.Vector(1536)
+  tool       ToolListing @relation(fields: [toolId], references: [id])
+  toolId     String
+}
+

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -1,0 +1,23 @@
+const prisma = require('../lib/prisma');
+const { embedText } = require('../services/openai');
+const { storeEmbedding } = require('../services/vector');
+
+async function main() {
+  const sampleTools = [
+    { title: 'AI Logo Generator', description: 'Generate logos using AI.' },
+    { title: 'Content Summarizer', description: 'Summarize long articles quickly.' }
+  ];
+
+  for (const tool of sampleTools) {
+    const listing = await prisma.toolListing.create({
+      data: { userId: 'seed-user', title: tool.title, description: tool.description }
+    });
+    const embedding = await embedText(`${tool.title}\n${tool.description}`);
+    await storeEmbedding(listing.id, `${tool.title}\n${tool.description}`, embedding);
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+}).finally(() => prisma.$disconnect());

--- a/scripts/setup.js
+++ b/scripts/setup.js
@@ -1,0 +1,10 @@
+const { execSync } = require('child_process');
+
+try {
+  execSync('npm install', { stdio: 'inherit' });
+  execSync('npx prisma generate', { stdio: 'inherit' });
+  console.log('Setup completed.');
+} catch (err) {
+  console.error('Setup failed:', err);
+  process.exit(1);
+}

--- a/services/openai.js
+++ b/services/openai.js
@@ -1,0 +1,23 @@
+const { OpenAI } = require('openai');
+
+const openai = new OpenAI({
+  apiKey: process.env.OPENAI_API_KEY
+});
+
+async function generateToolData(prompt) {
+  const completion = await openai.chat.completions.create({
+    model: 'gpt-4o',
+    messages: [{ role: 'system', content: 'You are the FoundaBrain AI Wizard.' }, { role: 'user', content: prompt }]
+  });
+  return completion.choices[0]?.message?.content;
+}
+
+async function embedText(text) {
+  const resp = await openai.embeddings.create({
+    model: 'text-embedding-3-small',
+    input: text
+  });
+  return resp.data[0].embedding;
+}
+
+module.exports = { generateToolData, embedText };

--- a/services/vector.js
+++ b/services/vector.js
@@ -1,0 +1,13 @@
+const prisma = require('../lib/prisma');
+
+async function storeEmbedding(toolId, content, embedding) {
+  return prisma.vectorEmbedding.create({
+    data: { toolId, content, embedding }
+  });
+}
+
+async function searchSimilar(embedding, limit = 5) {
+  return prisma.$queryRaw`SELECT * FROM "VectorEmbedding" ORDER BY embedding <-> ${embedding} LIMIT ${limit}`;
+}
+
+module.exports = { storeEmbedding, searchSimilar };


### PR DESCRIPTION
## Summary
- set up package.json with TypeScript toolchain
- trim Prisma schema to core models
- add OpenAI and vector service utilities
- implement tool submission route under /backend
- create freelancer dashboard page in Next.js

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685593415ee48320b3ae7898a1c8e5b2