### PR TITLE
Initialize FoundaBrain foundation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+DATABASE_URL="postgresql://user:password@localhost:5432/foundabrain"
+OPENAI_API_KEY=""
+PGVECTOR_URL="postgresql://user:password@localhost:5432/foundabrain"
+PORT=3001
+JWT_SECRET="changeme"
+SESSION_EXPIRY="1h"
+CMS_DEFAULT_PAGE_COUNT=5

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-# Google App Engine generated folder
-appengine-generated/
+node_modules/
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
-# AI-Marketplace-
+# FoundaBrain
+
+AI-powered freelance marketplace foundation.
+
+## Setup
+
+1. Copy `.env.example` to `.env` and update with your credentials.
+2. Run `npm run setup` to install packages and generate Prisma client.
+3. Use `npm run dev` to start the Next.js frontend.
+4. Run `node api/index.js` or your custom server to start the Express API.
+5. Seed sample data with `npm run seed`.
+6. Run tests with `npm test`.
+
+Environment variables include `DATABASE_URL`, `PGVECTOR_URL`, `OPENAI_API_KEY`, `PORT`, `JWT_SECRET`, `SESSION_EXPIRY`, and `CMS_DEFAULT_PAGE_COUNT`.
+
+## API Routes
+
+- `POST /api/register` – create a freelancer account
+- `POST /api/login` – obtain JWT token
+- `POST /api/tools/submit` – submit a tool (auth required)
+- `POST /api/admin/moderate` – approve/reject/flag tools (admin only)

--- a/api/index.js
+++ b/api/index.js
@@ -1,0 +1,31 @@
+require('../lib/env.validation');
+const express = require('express');
+const bodyParser = require('body-parser');
+
+const register = require('./routes/register');
+const login = require('./routes/login');
+const customerOnboard = require('./routes/customer.onboard');
+const submitTool = require('./routes/tools.submit');
+const listTools = require('./routes/tools.index');
+const recommendTool = require('./routes/tools.recommend');
+const adminModerate = require('./routes/admin.moderate');
+const cms = require('./routes/cms');
+
+const app = express();
+app.use(bodyParser.json());
+
+app.use('/api/register', register);
+app.use('/api/login', login);
+app.use('/api/customer/onboard', customerOnboard);
+app.use('/api/tools/submit', submitTool);
+app.use('/api/tools', listTools);
+app.use('/api/tools/recommend', recommendTool);
+app.use('/api/admin/moderate', adminModerate);
+app.use('/api/cms', cms);
+
+const port = process.env.PORT || 3001;
+app.listen(port, () => {
+  console.log(`API server running on port ${port}`);
+});
+
+module.exports = app;

--- a/api/routes/admin.moderate.js
+++ b/api/routes/admin.moderate.js
@@ -1,0 +1,38 @@
+const express = require('express');
+const prisma = require('../../lib/prisma');
+const { authenticate, requireRole } = require('../../services/auth');
+
+const router = express.Router();
+
+router.post('/', authenticate, requireRole('admin'), async (req, res) => {
+  const { toolId, action, comment } = req.body;
+  if (!toolId || !action) {
+    return res.status(400).json({ success: false, error: 'toolId and action required' });
+  }
+  try {
+    let status;
+    switch (action) {
+      case 'approve':
+        status = 'approved';
+        break;
+      case 'reject':
+        status = 'rejected';
+        break;
+      case 'flag':
+        status = 'flagged';
+        break;
+      default:
+        return res.status(400).json({ success: false, error: 'Invalid action' });
+    }
+    const listing = await prisma.toolListing.update({
+      where: { id: toolId },
+      data: { status, moderationComment: comment || null }
+    });
+    res.json({ success: true, data: listing });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ success: false, error: 'Internal server error' });
+  }
+});
+
+module.exports = router;

--- a/api/routes/cms.js
+++ b/api/routes/cms.js
@@ -1,0 +1,54 @@
+const express = require('express');
+const prisma = require('../../lib/prisma');
+const { authenticate, requireRole } = require('../../services/auth');
+
+const router = express.Router();
+
+router.get('/', async (_req, res) => {
+  try {
+    const pages = await prisma.cMSPage.findMany({ orderBy: { createdAt: 'desc' } });
+    res.json({ success: true, data: pages });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ success: false, error: 'Internal server error' });
+  }
+});
+
+router.post('/', authenticate, requireRole('admin'), async (req, res) => {
+  const { slug, title, content } = req.body;
+  if (!slug || !title) {
+    return res.status(400).json({ success: false, error: 'slug and title required' });
+  }
+  try {
+    const page = await prisma.cMSPage.create({ data: { slug, title, content } });
+    res.json({ success: true, data: page });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ success: false, error: 'Internal server error' });
+  }
+});
+
+router.put('/:id', authenticate, requireRole('admin'), async (req, res) => {
+  const { id } = req.params;
+  const { slug, title, content } = req.body;
+  try {
+    const page = await prisma.cMSPage.update({ where: { id }, data: { slug, title, content } });
+    res.json({ success: true, data: page });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ success: false, error: 'Internal server error' });
+  }
+});
+
+router.delete('/:id', authenticate, requireRole('admin'), async (req, res) => {
+  const { id } = req.params;
+  try {
+    await prisma.cMSPage.delete({ where: { id } });
+    res.json({ success: true });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ success: false, error: 'Internal server error' });
+  }
+});
+
+module.exports = router;

--- a/api/routes/customer.onboard.js
+++ b/api/routes/customer.onboard.js
@@ -1,0 +1,26 @@
+const express = require('express');
+const { generateToolData, embedText } = require('../../services/openai');
+const { searchSimilar } = require('../../services/vector');
+
+const router = express.Router();
+
+router.post('/', async (req, res) => {
+  const { prompt } = req.body;
+  if (!prompt) {
+    return res.status(400).json({ success: false, error: 'prompt required' });
+  }
+  try {
+    const embedding = await embedText(prompt);
+    let results = await searchSimilar(embedding);
+    if (!results || results.length === 0) {
+      const fallback = await generateToolData(`Suggest categories for: ${prompt}`);
+      return res.json({ success: true, data: { suggestions: fallback } });
+    }
+    res.json({ success: true, data: results });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ success: false, error: 'Internal server error' });
+  }
+});
+
+module.exports = router;

--- a/api/routes/login.js
+++ b/api/routes/login.js
@@ -1,0 +1,33 @@
+const express = require('express');
+const prisma = require('../../lib/prisma');
+const bcrypt = require('bcrypt');
+const jwt = require('jsonwebtoken');
+
+const router = express.Router();
+const SECRET = process.env.JWT_SECRET || 'secret';
+
+router.post('/', async (req, res) => {
+  const { email, password } = req.body;
+  if (!email || !password) {
+    return res.status(400).json({ success: false, error: 'email and password required' });
+  }
+  try {
+    const user = await prisma.user.findUnique({ where: { email } });
+    if (!user) {
+      return res.status(401).json({ success: false, error: 'Invalid credentials' });
+    }
+    const match = await bcrypt.compare(password, user.password);
+    if (!match) {
+      return res.status(401).json({ success: false, error: 'Invalid credentials' });
+    }
+    const token = jwt.sign({ userId: user.id, role: user.role }, SECRET, {
+      expiresIn: process.env.SESSION_EXPIRY || '1h'
+    });
+    res.json({ success: true, data: { token } });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ success: false, error: 'Internal server error' });
+  }
+});
+
+module.exports = router;

--- a/api/routes/register.js
+++ b/api/routes/register.js
@@ -1,0 +1,36 @@
+const express = require('express');
+const prisma = require('../../lib/prisma');
+const { generateToolData } = require('../../services/openai');
+const { login } = require('../../services/auth');
+const bcrypt = require('bcrypt');
+const rateLimit = require('express-rate-limit');
+
+const limiter = rateLimit({ windowMs: 60 * 1000, max: 5 });
+
+const router = express.Router();
+
+router.post('/', limiter, async (req, res) => {
+  const { email, password, prompt } = req.body;
+  if (!email || !password) {
+    return res.status(400).json({ success: false, error: 'email and password required' });
+  }
+  try {
+    const existing = await prisma.user.findUnique({ where: { email } });
+    if (existing) {
+      return res.status(400).json({ success: false, error: 'email already registered' });
+    }
+    let profileInfo = null;
+    if (prompt) {
+      profileInfo = await generateToolData(prompt);
+    }
+    const hashed = await bcrypt.hash(password, 10);
+    const user = await prisma.user.create({ data: { email, password: hashed, role: 'freelancer' } });
+    const token = await login(email, password);
+    res.json({ success: true, data: { id: user.id, profileInfo, token } });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ success: false, error: 'Internal server error' });
+  }
+});
+
+module.exports = router;

--- a/api/routes/tools.index.js
+++ b/api/routes/tools.index.js
@@ -1,0 +1,43 @@
+const express = require('express');
+const jwt = require('jsonwebtoken');
+const prisma = require('../../lib/prisma');
+
+const SECRET = process.env.JWT_SECRET || 'secret';
+
+function getUser(req) {
+  const auth = req.headers.authorization;
+  if (!auth) return null;
+  const token = auth.split(' ')[1];
+  try {
+    return jwt.verify(token, SECRET);
+  } catch {
+    return null;
+  }
+}
+
+const router = express.Router();
+
+router.get('/', async (req, res) => {
+  try {
+    const user = getUser(req);
+    const where = {};
+    if (req.query.mine && user) {
+      where.userId = user.userId;
+    } else if (!req.query.status) {
+      where.status = 'approved';
+    }
+    if (req.query.status) {
+      where.status = req.query.status;
+    }
+    const tools = await prisma.toolListing.findMany({
+      where,
+      orderBy: { createdAt: 'desc' }
+    });
+    res.json(tools);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ success: false, error: 'Internal server error' });
+  }
+});
+
+module.exports = router;

--- a/api/routes/tools.recommend.js
+++ b/api/routes/tools.recommend.js
@@ -1,0 +1,22 @@
+const express = require('express');
+const { embedText } = require('../../services/openai');
+const { searchSimilar } = require('../../services/vector');
+
+const router = express.Router();
+
+router.get('/', async (req, res) => {
+  const { query } = req.query;
+  if (!query) {
+    return res.status(400).json({ success: false, error: 'query required' });
+  }
+  try {
+    const embedding = await embedText(query);
+    const results = await searchSimilar(embedding);
+    res.json({ success: true, data: results });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ success: false, error: 'Internal server error' });
+  }
+});
+
+module.exports = router;

--- a/api/routes/tools.submit.js
+++ b/api/routes/tools.submit.js
@@ -1,0 +1,58 @@
+const express = require('express');
+const prisma = require('../../lib/prisma');
+const { generateToolData, embedText } = require('../../services/openai');
+const { storeEmbedding } = require('../../services/vector');
+const { authenticate, requireRole } = require('../../services/auth');
+const rateLimit = require('express-rate-limit');
+
+const limiter = rateLimit({ windowMs: 60 * 1000, max: 5 });
+
+const router = express.Router();
+
+router.post('/', limiter, authenticate, requireRole('freelancer'), async (req, res) => {
+  const { prompt } = req.body;
+  const userId = req.user.userId;
+  if (!prompt) {
+    return res.status(400).json({ success: false, error: 'prompt required' });
+  }
+  try {
+    let attempts = 0;
+    let parsed = {};
+    let aiContent = '';
+    const schema = '{"title","description","tags","useCase","problemSolved","clientInput","price"}';
+    while (attempts < 2) {
+      aiContent = await generateToolData(
+        attempts === 0 ? prompt : `Please provide clear JSON ${schema} for: ${prompt}`
+      );
+      try {
+        parsed = JSON.parse(aiContent);
+      } catch (e) {
+        parsed = {};
+        attempts++;
+        continue;
+      }
+      if (parsed.title && parsed.description) {
+        break;
+      }
+      attempts++;
+    }
+    const { title, description, tags = [], useCase = '', problemSolved = '', clientInput = '', price = 0 } = parsed;
+    if (!title || !description) {
+      return res.status(422).json({ success: false, error: 'AI could not interpret your description. Try rephrasing your description.' });
+    }
+    if (description.length < 20) {
+      return res.status(422).json({ success: false, error: 'AI response too short. Try rephrasing your description.' });
+    }
+    const listing = await prisma.toolListing.create({
+      data: { userId, title, description, tags, useCase, problemSolved, clientInput, price }
+    });
+    const embedding = await embedText(`${title}\n${description}`);
+    await storeEmbedding(listing.id, `${title}\n${description}`, embedding);
+    res.json({ success: true, data: listing });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ success: false, error: 'Internal server error' });
+  }
+});
+
+module.exports = router;

--- a/components/AdminToolList.tsx
+++ b/components/AdminToolList.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import ToolCard from './ToolCard';
+import axios from 'axios';
+
+export interface AdminTool {
+  id: string;
+  title: string;
+  description: string;
+  tags: string[];
+  price: number;
+  status: string;
+}
+
+export default function AdminToolList({ tools, refresh }: { tools: AdminTool[]; refresh: () => void }) {
+  const handleAction = async (toolId: string, action: 'approve' | 'reject') => {
+    await axios.post('/api/admin/moderate', { toolId, action });
+    refresh();
+  };
+
+  return (
+    <div>
+      {tools.map(tool => (
+        <div key={tool.id} style={{ marginBottom: '1rem' }}>
+          <ToolCard title={tool.title} description={tool.description} tags={tool.tags} price={tool.price} />
+          <p>Status: {tool.status}</p>
+          <button onClick={() => handleAction(tool.id, 'approve')} style={{ marginRight: '0.5rem' }}>Approve</button>
+          <button onClick={() => handleAction(tool.id, 'reject')}>Reject</button>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/components/Hero.module.css
+++ b/components/Hero.module.css
@@ -1,0 +1,35 @@
+.container {
+  text-align: center;
+  padding: 4rem 1rem;
+  background: url('/hero-bg.jpg') center/cover no-repeat;
+  color: #fff;
+}
+.heading {
+  font-size: 2.5rem;
+  font-weight: bold;
+  margin-bottom: 1rem;
+}
+.subheading {
+  font-size: 1.25rem;
+  margin-bottom: 2rem;
+}
+.inputRow {
+  display: flex;
+  justify-content: center;
+  max-width: 500px;
+  margin: 0 auto;
+}
+.input {
+  flex: 1;
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 4px 0 0 4px;
+}
+.button {
+  background-color: #2563eb;
+  color: #fff;
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 0 4px 4px 0;
+  cursor: pointer;
+}

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -1,0 +1,31 @@
+import { useState } from 'react';
+import styles from './Hero.module.css';
+
+interface HeroProps {
+  onFindTools: (query: string) => void;
+}
+
+export default function Hero({ onFindTools }: HeroProps) {
+  const [query, setQuery] = useState('');
+
+  return (
+    <section className={styles.container}>
+      <h1 className={styles.heading}>Find AI Tools for Your Business</h1>
+      <p className={styles.subheading}>
+        Instant access to powerful AI tools created by vetted freelancers.
+      </p>
+      <div className={styles.inputRow}>
+        <input
+          className={styles.input}
+          type="text"
+          placeholder="Tell us about your business..."
+          value={query}
+          onChange={e => setQuery(e.target.value)}
+        />
+        <button className={styles.button} onClick={() => onFindTools(query)}>
+          Find Tools
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/components/Navbar.module.css
+++ b/components/Navbar.module.css
@@ -1,0 +1,24 @@
+.container {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 2rem;
+  background-color: #ffffff;
+  border-bottom: 1px solid #e5e7eb;
+}
+.logo {
+  font-weight: bold;
+  font-size: 1.25rem;
+}
+.navLinks {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+.button {
+  background-color: #2563eb;
+  color: #fff;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  text-decoration: none;
+}

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,0 +1,18 @@
+import Link from 'next/link';
+import styles from './Navbar.module.css';
+
+export default function Navbar() {
+  return (
+    <nav className={styles.container}>
+      <div className={styles.logo}>FoundaBrain</div>
+      <div className={styles.navLinks}>
+        <Link href="/tool-listing">Browse Tools</Link>
+        <Link href="/login">Sign In</Link>
+        <Link href="/register">Join</Link>
+        <Link className={styles.button} href="/freelancer/dashboard">
+          Post a Tool
+        </Link>
+      </div>
+    </nav>
+  );
+}

--- a/components/ToolCard.tsx
+++ b/components/ToolCard.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+export interface ToolCardProps {
+  title: string;
+  description: string;
+  tags?: string[];
+  price?: number;
+}
+
+export default function ToolCard({ title, description, tags = [], price }: ToolCardProps) {
+  return (
+    <div className="tool-card" style={{ border: '1px solid #ccc', padding: '1rem', marginBottom: '1rem' }}>
+      <h3>{title}</h3>
+      <p>{description}</p>
+      {tags.length > 0 && <p>Tags: {tags.join(', ')}</p>}
+      {price !== undefined && <p>Price: ${price.toFixed(2)}</p>}
+    </div>
+  );
+}

--- a/components/WizardInput.tsx
+++ b/components/WizardInput.tsx
@@ -1,0 +1,33 @@
+import React, { useState } from 'react';
+
+export interface WizardInputProps {
+  onComplete: (value: string) => void;
+}
+
+export default function WizardInput({ onComplete }: WizardInputProps) {
+  const [step, setStep] = useState(0);
+  const [value, setValue] = useState('');
+
+  const steps = [
+    'Describe your problem',
+    'Provide any additional details'
+  ];
+
+  const handleNext = () => {
+    if (step < steps.length - 1) {
+      setStep(step + 1);
+    } else {
+      onComplete(value);
+    }
+  };
+
+  return (
+    <div>
+      <p>{steps[step]}</p>
+      <textarea value={value} onChange={e => setValue(e.target.value)} rows={4} style={{ width: '100%' }} />
+      <button onClick={handleNext} style={{ marginTop: '0.5rem' }}>
+        {step < steps.length - 1 ? 'Next' : 'Submit'}
+      </button>
+    </div>
+  );
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.ts$': 'ts-jest'
+  },
+  moduleFileExtensions: ['ts', 'js'],
+};

--- a/lib/env.validation.ts
+++ b/lib/env.validation.ts
@@ -1,0 +1,16 @@
+const required = [
+  'DATABASE_URL',
+  'PGVECTOR_URL',
+  'OPENAI_API_KEY',
+  'PORT',
+  'JWT_SECRET'
+];
+
+for (const key of required) {
+  if (!process.env[key]) {
+    console.error(`Missing environment variable ${key}`);
+    process.exit(1);
+  }
+}
+
+export {};

--- a/lib/prisma.js
+++ b/lib/prisma.js
@@ -1,0 +1,13 @@
+const { PrismaClient } = require('@prisma/client');
+
+let prisma;
+if (process.env.NODE_ENV === 'production') {
+  prisma = new PrismaClient();
+} else {
+  if (!global.prisma) {
+    global.prisma = new PrismaClient();
+  }
+  prisma = global.prisma;
+}
+
+module.exports = prisma;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "foundabrain",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "NODE_ENV=production node api/index.js",
+    "setup": "node scripts/setup.js",
+    "seed": "ts-node scripts/seed.ts",
+    "test": "jest"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "next": "13.4.13",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "pg": "^8.11.1",
+    "pgvector": "^0.1.7",
+    "openai": "^4.21.1",
+    "jsonwebtoken": "^9.0.2",
+    "bcrypt": "^5.1.1",
+    "express-rate-limit": "^7.1.0",
+    "prisma": "^5.9.0",
+    "@prisma/client": "^5.9.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.5",
+    "ts-node": "^10.9.2",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "supertest": "^6.3.3"
+  }
+}

--- a/pages/admin/cms.tsx
+++ b/pages/admin/cms.tsx
@@ -1,0 +1,29 @@
+import useSWR from 'swr';
+import axios from 'axios';
+
+interface CMSPage {
+  id: string;
+  slug: string;
+  title: string;
+  content: string;
+}
+
+const fetcher = (url: string) => axios.get(url).then(res => res.data.data);
+
+export default function CMSAdmin() {
+  const { data, error } = useSWR<CMSPage[]>('/api/cms', fetcher);
+
+  if (error) return <div>Error loading pages.</div>;
+  if (!data) return <div>Loading...</div>;
+
+  return (
+    <div>
+      <h1>CMS Pages</h1>
+      <ul>
+        {data.map(p => (
+          <li key={p.id}>{p.title} ({p.slug})</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -1,0 +1,22 @@
+import useSWR from 'swr';
+import axios from 'axios';
+import AdminToolList, { AdminTool } from '../../components/AdminToolList';
+
+const fetcher = (url: string) =>
+  axios
+    .get(url, { headers: { Authorization: `Bearer ${localStorage.getItem('token') || ''}` } })
+    .then(res => res.data);
+
+export default function AdminDashboard() {
+  const { data, error, mutate } = useSWR<AdminTool[]>('/api/tools?status=submitted', fetcher);
+
+  if (error) return <div>Error loading tools.</div>;
+  if (!data) return <div>Loading...</div>;
+
+  return (
+    <div>
+      <h1>Admin Dashboard</h1>
+      <AdminToolList tools={data} refresh={() => mutate()} />
+    </div>
+  );
+}

--- a/pages/customer-wizard.tsx
+++ b/pages/customer-wizard.tsx
@@ -1,0 +1,30 @@
+import { useState } from 'react';
+import WizardInput from '../components/WizardInput';
+import ToolCard from '../components/ToolCard';
+import axios from 'axios';
+
+interface ToolListing {
+  id: string;
+  title: string;
+  description: string;
+  tags: string[];
+  price: number;
+}
+
+export default function CustomerWizard() {
+  const [tools, setTools] = useState<ToolListing[] | null>(null);
+  const handleComplete = async (prompt: string) => {
+    const resp = await axios.post('/api/customer/onboard', { prompt });
+    setTools(resp.data.data);
+  };
+
+  return (
+    <div>
+      <h1>Customer Onboarding Wizard</h1>
+      {!tools && <WizardInput onComplete={handleComplete} />}
+      {tools && tools.map(t => (
+        <ToolCard key={t.id} title={t.title} description={t.description} tags={t.tags} price={t.price} />
+      ))}
+    </div>
+  );
+}

--- a/pages/freelancer/dashboard.tsx
+++ b/pages/freelancer/dashboard.tsx
@@ -1,0 +1,34 @@
+import useSWR from 'swr';
+import axios from 'axios';
+import ToolCard from '../../components/ToolCard';
+
+interface ToolListing {
+  id: string;
+  title: string;
+  description: string;
+  tags: string[];
+  price: number;
+}
+
+const fetcher = (url: string) =>
+  axios
+    .get(url, {
+      headers: { Authorization: `Bearer ${localStorage.getItem('token') || ''}` }
+    })
+    .then(res => res.data);
+
+export default function FreelancerDashboard() {
+  const { data, error } = useSWR<ToolListing[]>('/api/tools?mine=true', fetcher);
+
+  if (error) return <div>Error loading tools.</div>;
+  if (!data) return <div>Loading...</div>;
+
+  return (
+    <div>
+      <h1>Your Tools</h1>
+      {data.map(tool => (
+        <ToolCard key={tool.id} title={tool.title} description={tool.description} tags={tool.tags} price={tool.price} />
+      ))}
+    </div>
+  );
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,0 +1,7 @@
+export default function Home() {
+  return (
+    <div>
+      <h1>Welcome to FoundaBrain</h1>
+    </div>
+  );
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,7 +1,0 @@
-export default function Home() {
-  return (
-    <div>
-      <h1>Welcome to FoundaBrain</h1>
-    </div>
-  );
-}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,0 +1,94 @@
+import { useState } from 'react';
+import Hero from '../components/Hero';
+import ToolCard from '../components/ToolCard';
+import Navbar from '../components/Navbar';
+import styles from '../styles/Home.module.css';
+
+interface Tool {
+  id: number;
+  title: string;
+  useCase: string;
+  rating: number;
+  price: number;
+  image: string;
+  category: string;
+}
+
+const sampleTools: Tool[] = [
+  { id: 1, title: 'AI Writer', useCase: 'Writing', rating: 4.8, price: 29, image: '/tool1.png', category: 'Writing' },
+  { id: 2, title: 'Marketing Genius', useCase: 'Marketing', rating: 4.5, price: 49, image: '/tool2.png', category: 'Marketing' },
+  { id: 3, title: 'Site Builder AI', useCase: 'Websites', rating: 4.7, price: 59, image: '/tool3.png', category: 'Websites' },
+  { id: 4, title: 'Code Buddy', useCase: 'Coding', rating: 4.6, price: 19, image: '/tool4.png', category: 'Coding' },
+  { id: 5, title: 'AI Ads Optimizer', useCase: 'Marketing', rating: 4.4, price: 39, image: '/tool5.png', category: 'Marketing' },
+  { id: 6, title: 'Blog Booster', useCase: 'Writing', rating: 4.3, price: 25, image: '/tool6.png', category: 'Writing' }
+];
+
+const categories = ['All', 'Marketing', 'Writing', 'Websites', 'Coding'];
+
+export default function Home() {
+  const [selected, setSelected] = useState('All');
+
+  const filtered =
+    selected === 'All' ? sampleTools : sampleTools.filter(t => t.category === selected);
+
+  const handleFindTools = (query: string) => {
+    // placeholder for search
+    console.log('Searching for', query);
+  };
+
+  return (
+    <div>
+      <Navbar />
+      <Hero onFindTools={handleFindTools} />
+      <section className={styles.featured} id="featured">
+        <h2>Featured AI Tools</h2>
+        <div className={styles.filters}>
+          {categories.map(cat => (
+            <button
+              key={cat}
+              onClick={() => setSelected(cat)}
+              className={selected === cat ? styles.activeFilter : ''}
+            >
+              {cat}
+            </button>
+          ))}
+        </div>
+        <div className={styles.grid}>
+          {filtered.map(tool => (
+            <div key={tool.id} className={styles.cardWrap}>
+              <img src={tool.image} alt={tool.title} className={styles.image} />
+              <ToolCard
+                title={tool.title}
+                description={tool.useCase}
+                price={tool.price}
+              />
+            </div>
+          ))}
+        </div>
+      </section>
+      <section className={styles.howItWorks}>
+        <h2>How It Works</h2>
+        <div className={styles.steps}>
+          <div>
+            <img src="/step1.svg" alt="Describe" />
+            <p>Describe your business</p>
+          </div>
+          <div>
+            <img src="/step2.svg" alt="Recommend" />
+            <p>Get personalized AI recommendations</p>
+          </div>
+          <div>
+            <img src="/step3.svg" alt="Connect" />
+            <p>Connect with trusted tool creators</p>
+          </div>
+        </div>
+      </section>
+      <section className={styles.freelancerCta}>
+        <h2>Build AI Tools? Share your solution on FoundaBrain.</h2>
+        <a href="/freelancer/dashboard" className={styles.ctaButton}>
+          Join as a Freelancer
+        </a>
+      </section>
+    </div>
+  );
+}

--- a/pages/tool-listing.js
+++ b/pages/tool-listing.js
@@ -1,0 +1,7 @@
+export default function ToolListing() {
+  return (
+    <div>
+      <h1>Tool Listing</h1>
+    </div>
+  );
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,74 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model User {
+  id        String   @id @default(uuid())
+  email     String   @unique
+  password  String
+  role      Role
+  createdAt DateTime @default(now())
+  listings  ToolListing[]
+  threads   MessageThread[] @relation("MessageThreads")
+}
+
+enum Role {
+  freelancer
+  customer
+  admin
+}
+
+enum ModerationStatus {
+  submitted
+  approved
+  needs_review
+  rejected
+  flagged
+}
+
+model ToolListing {
+  id          String   @id @default(uuid())
+  user        User     @relation(fields: [userId], references: [id])
+  userId      String
+  title       String
+  description String
+  tags        String[]
+  useCase     String
+  problemSolved String
+  clientInput String
+  price       Decimal   @db.Decimal
+  createdAt   DateTime @default(now())
+  embedding   VectorEmbedding?
+  status      ModerationStatus @default(submitted)
+  adminComment String?
+  moderationComment String?
+}
+
+model VectorEmbedding {
+  id         String   @id @default(uuid())
+  content    String
+  embedding  Float[]  @db.Vector(1536)
+  tool       ToolListing @relation(fields: [toolId], references: [id])
+  toolId     String
+}
+
+model MessageThread {
+  id        String   @id @default(uuid())
+  users     User[]   @relation("MessageThreads")
+  createdAt DateTime @default(now())
+}
+
+model CMSPage {
+  id        String   @id @default(uuid())
+  slug      String   @unique
+  title     String
+  content   String
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+}
+

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -1,0 +1,63 @@
+import prisma from '../lib/prisma';
+import { embedText } from '../services/openai';
+import { storeEmbedding } from '../services/vector';
+import bcrypt from 'bcrypt';
+
+async function main() {
+  const passwordHash = await bcrypt.hash('password', 10);
+  const user = await prisma.user.create({
+    data: { email: 'freelancer@test.com', password: passwordHash, role: 'freelancer' }
+  });
+
+  const sampleTools = [
+    {
+      title: 'AI Logo Generator',
+      description: 'Generate logos using AI.',
+      tags: ['design', 'logo'],
+      useCase: 'Branding assets',
+      problemSolved: 'Creating custom logos',
+      clientInput: 'Company name and style preferences',
+      price: 49.99
+    },
+    {
+      title: 'Content Summarizer',
+      description: 'Summarize long articles quickly.',
+      tags: ['nlp', 'summarization'],
+      useCase: 'Article summarization',
+      problemSolved: 'Reducing reading time',
+      clientInput: 'Article URL or text',
+      price: 29.99
+    },
+    {
+      title: 'AI Code Reviewer',
+      description: 'Automatically review pull requests for style and bugs.',
+      tags: ['code', 'review', 'automation'],
+      useCase: 'Code quality enforcement',
+      problemSolved: 'Manual code review overhead',
+      clientInput: 'GitHub repository URL',
+      price: 99.0
+    }
+  ];
+
+  for (const tool of sampleTools) {
+    const listing = await prisma.toolListing.create({
+      data: {
+        userId: user.id,
+        title: tool.title,
+        description: tool.description,
+        tags: tool.tags,
+        useCase: tool.useCase,
+        problemSolved: tool.problemSolved,
+        clientInput: tool.clientInput,
+        price: tool.price
+      }
+    });
+    const embedding = await embedText(`${tool.title}\n${tool.description}`);
+    await storeEmbedding(listing.id, `${tool.title}\n${tool.description}`, embedding);
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+}).finally(() => prisma.$disconnect());

--- a/scripts/setup.js
+++ b/scripts/setup.js
@@ -1,0 +1,21 @@
+const { execSync } = require('child_process');
+
+function run(cmd) {
+  execSync(cmd, { stdio: 'inherit' });
+}
+
+try {
+  run('npm install');
+} catch (err) {
+  console.error('npm install failed. Check your network or proxy settings.');
+  process.exit(1);
+}
+
+try {
+  run('npx prisma migrate deploy');
+  run('npx ts-node scripts/seed.ts');
+  console.log('Setup completed.');
+} catch (err) {
+  console.error('Setup failed:', err);
+  process.exit(1);
+}

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -1,0 +1,1 @@
+console.log('No tests specified.');

--- a/services/auth.js
+++ b/services/auth.js
@@ -1,0 +1,37 @@
+const jwt = require('jsonwebtoken');
+const bcrypt = require('bcrypt');
+const prisma = require('../lib/prisma');
+
+const SECRET = process.env.JWT_SECRET || 'secret';
+
+async function login(email, password) {
+  const user = await prisma.user.findUnique({ where: { email } });
+  if (!user) return null;
+  const match = await bcrypt.compare(password, user.password);
+  if (!match) return null;
+  const token = jwt.sign({ userId: user.id, role: user.role }, SECRET, { expiresIn: '1h' });
+  return token;
+}
+
+function authenticate(req, res, next) {
+  const auth = req.headers.authorization;
+  if (!auth) return res.status(401).json({ error: 'Unauthorized' });
+  const token = auth.split(' ')[1];
+  try {
+    req.user = jwt.verify(token, SECRET);
+    next();
+  } catch (err) {
+    res.status(401).json({ error: 'Unauthorized' });
+  }
+}
+
+function requireRole(role) {
+  return (req, res, next) => {
+    if (!req.user || req.user.role !== role) {
+      return res.status(403).json({ error: 'Forbidden' });
+    }
+    next();
+  };
+}
+
+module.exports = { login, authenticate, requireRole };

--- a/services/openai.js
+++ b/services/openai.js
@@ -1,0 +1,23 @@
+const { OpenAI } = require('openai');
+
+const openai = new OpenAI({
+  apiKey: process.env.OPENAI_API_KEY
+});
+
+async function generateToolData(prompt) {
+  const completion = await openai.chat.completions.create({
+    model: 'gpt-4o',
+    messages: [{ role: 'system', content: 'You are the FoundaBrain AI Wizard.' }, { role: 'user', content: prompt }]
+  });
+  return completion.choices[0]?.message?.content;
+}
+
+async function embedText(text) {
+  const resp = await openai.embeddings.create({
+    model: 'text-embedding-3-small',
+    input: text
+  });
+  return resp.data[0].embedding;
+}
+
+module.exports = { generateToolData, embedText };

--- a/services/vector.js
+++ b/services/vector.js
@@ -1,0 +1,16 @@
+const prisma = require('../lib/prisma');
+const { sql } = require('@prisma/client');
+
+async function storeEmbedding(toolId, content, embedding) {
+  return prisma.vectorEmbedding.create({
+    data: { toolId, content, embedding }
+  });
+}
+
+async function searchSimilar(embedding, limit = 5) {
+  return prisma.$queryRaw(
+    sql`SELECT t.*, ve.content FROM "VectorEmbedding" ve JOIN "ToolListing" t ON t.id = ve."toolId" WHERE t.status = 'approved' ORDER BY ve.embedding <-> ${embedding} LIMIT ${limit}`
+  );
+}
+
+module.exports = { storeEmbedding, searchSimilar };

--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -1,0 +1,60 @@
+.featured {
+  padding: 2rem 1rem;
+  text-align: center;
+}
+.filters {
+  margin-bottom: 1rem;
+}
+.filters button {
+  margin: 0 0.5rem;
+  padding: 0.5rem 1rem;
+  border: none;
+  background: #e5e7eb;
+  cursor: pointer;
+}
+.activeFilter {
+  background: #2563eb;
+  color: #fff;
+}
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 1rem;
+  margin-top: 1rem;
+}
+.cardWrap {
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 4px;
+  padding: 1rem;
+}
+.image {
+  width: 100%;
+  height: 120px;
+  object-fit: cover;
+  margin-bottom: 0.5rem;
+}
+.howItWorks {
+  padding: 2rem 1rem;
+  background: #f9fafb;
+  text-align: center;
+}
+.steps {
+  display: flex;
+  justify-content: center;
+  gap: 2rem;
+  margin-top: 1rem;
+}
+.freelancerCta {
+  padding: 2rem 1rem;
+  text-align: center;
+}
+.ctaButton {
+  display: inline-block;
+  margin-top: 1rem;
+  padding: 0.5rem 1rem;
+  background: #2563eb;
+  color: #fff;
+  border-radius: 4px;
+  text-decoration: none;
+}

--- a/tests/tools.submit.test.ts
+++ b/tests/tools.submit.test.ts
@@ -1,0 +1,9 @@
+import request from 'supertest';
+import app from '../api/index';
+
+describe('POST /api/tools/submit', () => {
+  it('requires authentication', async () => {
+    const res = await request(app).post('/api/tools/submit').send({ prompt: 'test' });
+    expect(res.status).toBe(401);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "baseUrl": ".",
+    "paths": {
+      "@api/*": ["api/*"],
+      "@lib/*": ["lib/*"],
+      "@services/*": ["services/*"]
+    }
+  },
+  "include": ["api/**/*", "lib/**/*", "services/**/*", "scripts/**/*", "components/**/*", "pages/**/*", "tests/**/*"]
+}


### PR DESCRIPTION
## Summary
- streamline moderation route and admin component
- hash passwords with bcrypt during register and login
- seed script creates a sample freelancer and tools
- join tool data in vector recommendations
- filter tools by owner on freelancer dashboard
- add login route, env validation, rate limiting, tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685593415ee48320b3ae7898a1c8e5b2